### PR TITLE
feat: integrate Swagger for API documentation

### DIFF
--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -1,11 +1,14 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
 
 @Controller()
+@ApiTags('App')
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Get Hello World', description: 'Returns a Hello World string.' })
   getHello(): string {
     return this.appService.getHello();
   }

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,8 +1,19 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Swagger configuration
+  const config = new DocumentBuilder()
+    .setTitle('SkillSync API')
+    .setDescription('API documentation for SkillSync application')
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document);
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
- Installed @nestjs/swagger and swagger-ui-express
- Configured Swagger in [main.ts](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) with title, version, and description
- Added Swagger decorators (@ApiTags, @ApiOperation) to AppController
- Swagger UI available at /api/docs